### PR TITLE
Lua scripting

### DIFF
--- a/ila-cli/Cargo.lock
+++ b/ila-cli/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -40,44 +34,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -87,9 +81,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -104,10 +98,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.17.0"
+name = "bstr"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -123,35 +127,35 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -162,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -172,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -184,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -196,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-macro"
@@ -210,15 +214,15 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -230,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -250,7 +254,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -271,30 +275,30 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -302,11 +306,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -316,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -327,15 +330,15 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -345,19 +348,19 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -367,9 +370,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "format_num_pattern"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39657b084f99a6df45351bac3df5f764acc57e7191f90efd6acd51e3256070a6"
+checksum = "c65555758fa179289adca4d06baac02d27a8a101d0dc4a04f3dc82d0a6c36555"
 dependencies = [
  "log",
  "memchr",
@@ -383,6 +386,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -410,9 +437,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -447,6 +474,7 @@ dependencies = [
  "cli-macro",
  "crossterm",
  "csv",
+ "mlua",
  "num",
  "rat-focus",
  "rat-text",
@@ -459,15 +487,18 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
@@ -488,15 +519,15 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iset"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855de4169757ca6b92b396d7a0380ef234e9a1ec2ec603c80779453ed0ab45e4"
+checksum = "a4d5f8699985a95af72fe8d67484b0b036df7500e0d68e769adc198180da2011"
 
 [[package]]
 name = "itertools"
@@ -509,25 +540,27 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -537,19 +570,18 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -561,30 +593,80 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach2"
-version = "0.4.2"
+name = "lua-src"
+version = "550.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+checksum = "e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.6.6+707c12b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mlua"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
+dependencies = [
+ "bstr",
+ "either",
+ "futures-util",
+ "libc",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "rustversion",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -673,15 +755,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -689,15 +777,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -707,25 +795,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.95"
+name = "pin-project-lite"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pure-rust-locales"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
+checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -738,15 +838,15 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rat-cursor"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37427a103efff37496fad20528e767ba658737e731dff1cf9231104859455dc0"
+checksum = "7d7c7dfdb4219fa10891a06232b071460a66ccd15ce627e3764d63c0371eb9f5"
 
 [[package]]
 name = "rat-event"
-version = "1.2.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e333b72bcd23f28ac85ba6441c5e75600ace55947e71930e7cb327e6716286"
+checksum = "4dcea89a6638a3bb9dc3b0b24605dc883017210e5333af88bff1e9b73ee75866"
 dependencies = [
  "crossterm",
  "log",
@@ -755,11 +855,12 @@ dependencies = [
 
 [[package]]
 name = "rat-focus"
-version = "1.0.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ba7cfef5aa7bec283ad631c82eb41b9bc9dcce3384d10bf392542a573e40de"
+checksum = "8aa2972f34e1818795c7f4eb4b0829fe475e4c5309aa051c03c7f7d9e8900195"
 dependencies = [
  "crossterm",
+ "dyn-clone",
  "fxhash",
  "log",
  "rat-event",
@@ -769,19 +870,18 @@ dependencies = [
 
 [[package]]
 name = "rat-reloc"
-version = "1.1.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbddcf2d92aae0efb227180c07d8fbbb4480cd30318e4e6f5825aae8f6dc5ba5"
+checksum = "bcd0715b910956d845c342cc570b17685a154768b2d05b555cd95fbc137138d5"
 dependencies = [
- "log",
  "ratatui",
 ]
 
 [[package]]
 name = "rat-scrolled"
-version = "1.1.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7110d840d57dc76785c1fbb76814c162772d975414d37ce931bfa2296b1f8f45"
+checksum = "585fbabc56eb553531f2caf807ad77e3198dd609f4885550dcc984098f5ccff7"
 dependencies = [
  "crossterm",
  "log",
@@ -792,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "rat-text"
-version = "1.0.4"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c923ab42cee656bed589c2cbc2b454f4ead356fe91cc5d22bcbe497dfb36ba0"
+checksum = "f341f6c731e007fa3e1e868d2a5218b5aa3a7ca387867c2aea49d669bf514554"
 dependencies = [
  "chrono",
  "crossterm",
@@ -810,6 +910,7 @@ dependencies = [
  "rat-scrolled",
  "ratatui",
  "ropey",
+ "rustc-hash",
  "unicode-display-width",
  "unicode-segmentation",
 ]
@@ -820,7 +921,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -837,11 +938,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -855,12 +956,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -869,15 +976,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -887,18 +994,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -907,23 +1024,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serialport"
-version = "4.7.1"
+version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daa7abb9b965493e3c8f4184c6f46435484ff2538a332b886788cf6768b927b"
+checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "core-foundation",
  "core-foundation-sys",
@@ -932,20 +1050,20 @@ dependencies = [
  "nix",
  "scopeguard",
  "unescaper",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -953,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -964,18 +1082,25 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.0"
+name = "slab"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "static_assertions"
@@ -1019,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1036,18 +1161,18 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1056,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "unescaper"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c878a167baa8afd137494101a688ef8c67125089ff2249284bd2b5f9bfedb815"
+checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
 dependencies = [
  "thiserror",
 ]
@@ -1074,15 +1199,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -1121,41 +1246,28 @@ checksum = "4505774fc84de82eb04caa74d859342b0daa376f4c6df45149593245dd62c004"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1163,24 +1275,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "which"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1207,9 +1328,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1220,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1231,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1242,24 +1363,24 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -1280,6 +1401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1354,3 +1484,9 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/ila-cli/Cargo.toml
+++ b/ila-cli/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = { version = "1.0.140", features = ["arbitrary_precision"] }
 serialport = { version = "4.7.0", default-features = false }
 vcd = "0.7.0"
 cli-macro = { path = "../cli-macro" }
+mlua = { version = "0.11", features = ["lua54", "vendored", "async"] }

--- a/ila-cli/src/cli.rs
+++ b/ila-cli/src/cli.rs
@@ -221,6 +221,7 @@ pub struct TuiArgs {
 impl ParseSubcommand for TuiArgs {
     fn parse(self) {
         let mut tx_port = find_specified_port(&self.port, self.baud);
+
         let config = self
             .config
             .get_config()

--- a/ila-cli/src/communication.rs
+++ b/ila-cli/src/communication.rs
@@ -26,6 +26,19 @@ pub fn bv_to_bytes(v: &BitVec<u8, Msb0>) -> Vec<u8> {
     vec
 }
 
+/// Converts a [`BigUint`] into a sample in the format used by the ILA.
+pub fn biguint_to_sample(n: &BigUint, width: usize) -> BitVec<u8, Msb0> {
+    let reference: BitVec<u8, Msb0> = BitVec::from_vec(n.to_bytes_be());
+    let mut base: BitVec<u8, Msb0> = BitVec::with_capacity(width);
+    for index in (0..width).rev() {
+        base.push(match reference.len().checked_sub(index + 1) {
+            Some(index) => reference[index],
+            None => false,
+        });
+    }
+    base
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReadWrite<R, W> {
     Read(R),

--- a/ila-cli/src/config.rs
+++ b/ila-cli/src/config.rs
@@ -10,6 +10,14 @@ pub struct IlaSignal {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IlaTrigger {
+    /// Name of the trigger which is displayed in the TUI.
+    pub name: String,
+    /// Unique identifier of trigger used in Lua config.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct IlaConfig {
     pub toplevel: String,
     #[serde(rename = "bufferSize")]
@@ -18,6 +26,8 @@ pub struct IlaConfig {
     pub signals: Vec<IlaSignal>,
     #[serde(rename = "triggerNames")]
     pub trigger_names: Vec<String>,
+    #[serde(rename = "triggerIds")]
+    pub trigger_ids: Vec<String>,
 }
 
 impl IlaConfig {

--- a/ila-cli/src/lua.rs
+++ b/ila-cli/src/lua.rs
@@ -1,0 +1,172 @@
+//! Module for integrating the Lua programming language with the ILA-CLI.
+
+use std::time::Duration;
+
+use mlua::prelude::*;
+use num::BigUint;
+
+use crate::communication::{biguint_to_sample, Signal, SignalCluster};
+use crate::config::{IlaConfig, IlaSignal};
+use crate::predicates::{IlaPredicate, PredicateOperation, PredicateTarget};
+use crate::predicates_tui::NumericState;
+use crate::tui::TuiAction;
+
+#[derive(Debug, Clone)]
+pub struct LuaVm {
+    vm: Lua,
+}
+
+impl FromLua for PredicateOperation {
+    fn from_lua(value: LuaValue, lua: &Lua) -> LuaResult<Self> {
+        let s = String::from_lua(value, lua)?;
+        match s.as_str() {
+            "or" => Ok(Self::Or),
+            "and" => Ok(Self::And),
+            _ => Err(LuaError::runtime(format!(
+                "invalid predicate operation: `{s}`, expected `and` or `or`"
+            ))),
+        }
+    }
+}
+
+fn cluster_from_lua(value: LuaValue, signals: &Vec<IlaSignal>) -> LuaResult<SignalCluster> {
+    let LuaValue::Table(sample) = value else {
+        return Err(LuaError::RuntimeError(
+            format!("{:?} {}", value, "expected a table".to_string()),
+        ));
+    };
+
+    let cluster: Vec<_> = (1..=sample.len().unwrap())
+        .map(|index| sample.get::<String>(index).unwrap())
+        .zip(signals)
+        .filter_map(|(input, signal)| {
+            NumericState::immediate_parse(&input)
+                .ok()
+                .map(|n| (n, signal))
+        })
+        .filter(|(n, signal)| {
+            *n < BigUint::new(vec![2]).pow(signal.width as u32)
+        })
+        .map(|(n, signal)| Signal {
+            name: signal.name.clone(),
+            width: signal.width,
+            samples: vec![biguint_to_sample(&n, signal.width)],
+        })
+        .collect();
+
+    Ok(SignalCluster {
+        cluster,
+        timestamp: Duration::ZERO,
+    })
+}
+
+fn predicate_from_lua(value: LuaValue, target: PredicateTarget, inputs: &Vec<IlaSignal>) -> LuaResult<IlaPredicate> {
+    let LuaValue::Table(value) = value else {
+        return Err(LuaError::RuntimeError(
+            "expected a table".to_string(),
+        ));
+    };
+
+    Ok(IlaPredicate {
+        target,
+        operation: value.get::<PredicateOperation>("combine")?,
+        mask: cluster_from_lua(value.get("masks")?, inputs)?,
+        compare: cluster_from_lua(value.get("compares")?, inputs)?,
+        predicate_select: 0,
+    })
+}
+
+impl IntoLua for IlaConfig {
+    fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
+        let config = lua.create_table()?;
+        config.set("toplevel", self.toplevel.clone())?;
+        config.set("hash", self.hash.clone())?;
+        config.set("buffer_size", self.buffer_size)?;
+
+        let inputs: Vec<LuaTable> = self
+            .signals
+            .iter()
+            .map(|signal| {
+                let input = lua.create_table()?;
+                input.set("name", signal.name.clone())?;
+                input.set("width", signal.width)?;
+                Ok(input)
+            })
+            .collect::<LuaResult<_>>()?;
+
+        config.set("inputs", lua.create_sequence_from(inputs)?)?;
+
+        Ok(LuaValue::Table(config))
+    }
+}
+
+impl LuaVm {
+    /// Constructs a new Lua VM with functions and variables for the ILA.
+    pub fn new(config: &IlaConfig) -> LuaResult<Self> {
+        let vm = Lua::new();
+
+        let LuaValue::Table(ila) = config.clone().into_lua(&vm)? else {
+            return Err(LuaError::RuntimeError(
+                "expected `ila` to be a table".to_string(),
+            ));
+        };
+
+        vm.set_app_data::<Vec<TuiAction>>(Vec::new());
+
+        vm.globals().set(
+            "print",
+            vm.create_function(|lua, s: String| {
+                if let Some(mut actions) = lua.app_data_mut::<Vec<TuiAction>>() {
+                    actions.push(TuiAction::Print(s));
+                }
+                Ok(())
+            })?,
+        )?;
+
+        let config = config.clone();
+
+        ila.set(
+            "config",
+            vm.create_function(move |lua, table: mlua::Table| {
+                let mut actions = lua.app_data_mut::<Vec<TuiAction>>().unwrap();
+
+                if let Ok(true) = table.contains_key("trigger_point") {
+                    actions.push(TuiAction::SetTriggerPoint(table.get::<u32>("trigger_point")?));
+                }
+
+                if let Ok(true) = table.contains_key("auto_rearm") {
+                    actions.push(TuiAction::SetAutoRearm(table.get::<bool>("auto_rearm")?));
+                }
+
+                if let Ok(true) = table.contains_key("trigger") {
+                    let predicate = predicate_from_lua(table.get("trigger")?, PredicateTarget::Trigger, &config.signals)?;
+                    actions.push(TuiAction::SetPredicate(predicate));
+                }
+
+                if let Ok(true) = table.contains_key("capture") {
+                    let predicate = predicate_from_lua(table.get("capture")?, PredicateTarget::Capture, &config.signals)?;
+                    actions.push(TuiAction::SetPredicate(predicate));
+                }
+
+                Ok(())
+            })?,
+        )?;
+
+        vm.globals().set("ila", LuaValue::Table(ila))?;
+
+        Ok(LuaVm { vm })
+    }
+
+    /// Executes Lua code.
+    pub fn exec(&mut self, code: &str) -> LuaResult<Vec<TuiAction>> {
+        self.vm.load(code).exec()?;
+
+        let actions = self
+            .vm
+            .app_data_mut::<Vec<TuiAction>>()
+            .map(|mut data| std::mem::take(&mut *data))
+            .unwrap_or_default();
+
+        Ok(actions)
+    }
+}

--- a/ila-cli/src/main.rs
+++ b/ila-cli/src/main.rs
@@ -13,6 +13,7 @@ mod wishbone;
 mod cli;
 mod cli_registers;
 mod export;
+mod lua;
 
 #[derive(Parser, Debug)]
 #[command(version, about)]

--- a/ila-cli/src/predicates_tui.rs
+++ b/ila-cli/src/predicates_tui.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    communication::{Signal, SignalCluster, bv_to_bytes},
+    communication::{Signal, SignalCluster, biguint_to_sample, bv_to_bytes},
     config::{IlaConfig, IlaSignal},
     predicates::{IlaPredicate, PredicateOperation, PredicateTarget},
     ui::textinput::TextPromptState,
@@ -534,19 +534,10 @@ impl State<'_> {
                 ..
             }) => {
                 fn biguint_to_signal((n, signal): (BigUint, &IlaSignal)) -> Signal {
-                    let reference: BitVec<u8, Msb0> = BitVec::from_vec(n.to_bytes_be());
-                    let mut base: BitVec<u8, Msb0> = BitVec::with_capacity(signal.width);
-                    for index in (0..signal.width).rev() {
-                        base.push(match reference.len().checked_sub(index + 1) {
-                            Some(index) => reference[index],
-                            None => false,
-                        });
-                    }
-
                     Signal {
                         name: signal.name.clone(),
                         width: signal.width,
-                        samples: vec![base],
+                        samples: vec![biguint_to_sample(&n, signal.width)],
                     }
                 }
 

--- a/ila-cli/src/tui.rs
+++ b/ila-cli/src/tui.rs
@@ -21,7 +21,7 @@ use ratatui::{
 use crate::cli_registers::IlaRegisters;
 use crate::communication::{RegisterOutput, SignalCluster, perform_buffer_reads, perform_register_operation};
 use crate::config::IlaConfig;
-use crate::predicates::IlaPredicate;
+use crate::predicates::{IlaPredicate};
 use crate::predicates::PredicateTarget;
 use crate::predicates_tui::State as PredState;
 use crate::ui::textinput::TextPromptState;
@@ -38,6 +38,19 @@ const KEYBIND_TEXT: &str = r#"  CTRL-c ---   Exit
   a      ---   Toggle auto trigger re-arm
   v      ---   Write signals to VCD dump
 "#;
+
+/// Action to be performed by the TUI.
+#[derive(Debug, Clone)]
+pub enum TuiAction {
+    /// Configure the ILA's trigger point. This value should not exceed the ILA's buffer size.
+    SetTriggerPoint(u32),
+    /// Configure auto-rearm.
+    SetAutoRearm(bool),
+    /// Appends a message to the log section of the TUI.
+    Print(String),
+    /// Configure one of the ILA's predicates.
+    SetPredicate(IlaPredicate),
+}
 
 /// The reason to prompt the user with, mostly important to decide what to do next after a user has
 /// inputted data to the prompt
@@ -82,10 +95,10 @@ pub struct TuiSession<'a> {
     /// In what state is the TUI currently at?
     state: TuiState<'a>,
     /// The ILA configuration, specifying certain aspects of the ILA
-    config: &'a IlaConfig,
+    pub config: &'a IlaConfig,
     /// A log for interactions to log their activity too, regularly gets truncated to fit the
     /// screen during rendering
-    log: Vec<String>,
+    pub log: Vec<String>,
     /// A list of signal clusters captured by the ILA
     captured: Vec<SignalCluster>,
     /// Checks if the predicate is triggered or not
@@ -103,6 +116,8 @@ pub struct TuiSession<'a> {
     auto_reset: bool,
     /// The connected device path
     device_path: String,
+
+    actions: Vec<TuiAction>,
 }
 
 impl<'a> TuiSession<'a> {
@@ -116,7 +131,7 @@ impl<'a> TuiSession<'a> {
         execute!(stdout, EnterAlternateScreen)?;
         let backend = CrosstermBackend::new(stdout);
 
-        Ok(TuiSession {
+        let mut session = TuiSession {
             term: Terminal::new(backend)?,
             state: TuiState::Main,
             config,
@@ -128,7 +143,67 @@ impl<'a> TuiSession<'a> {
             last_trigger_check: Instant::now(),
             auto_reset: false,
             device_path: device_path.display().to_string(),
-        })
+            actions: Vec::new(),
+        };
+
+        let actions = match std::fs::read_to_string(".ila.lua") {
+            Ok(script) => {
+                let mut lua = crate::lua::LuaVm::new(config).unwrap();
+
+                match lua.exec(&script) {
+                    Ok(actions) => actions,
+                    Err(e) => {
+                        e.to_string().lines().for_each(|s| session.log.push(s.to_string()));
+                        vec![]
+                    },
+                }
+            },
+            _ => vec![],
+        };
+
+        session.actions = actions;
+
+        Ok(session)
+    }
+
+    fn perform_action<T: Read + Write>(&mut self, tx_port: &mut T, action: &TuiAction) -> KeyResponse {
+        match action {
+            TuiAction::SetTriggerPoint(n) => {
+                let (msg, response) = match perform_register_operation(
+                    tx_port,
+                    self.config,
+                    &IlaRegisters::TriggerPoint(*n),
+                ) {
+                    Ok(_) => (
+                        String::from("Trigger point change made"),
+                        KeyResponse::AppliedChanges,
+                    ),
+                    Err(err) => (format!("Error: {err}"), KeyResponse::Nothing),
+                };
+                self.log.push(msg);
+                response
+            },
+            TuiAction::SetAutoRearm(b) => {
+                self.auto_reset = *b;
+                KeyResponse::Nothing
+            },
+            TuiAction::Print(ref message) => {
+                self.log.push(message.clone());
+                KeyResponse::Nothing
+            },
+            TuiAction::SetPredicate(predicate) => {
+                match predicate.update_ila(tx_port, self.config) {
+                    Ok(_) => {
+                        self.log.push("Succesfully updated predicate state".into());
+                        KeyResponse::AppliedChanges
+                    },
+                    Err(err) => {
+                        self.log.push(format!("Failed to update ILA with error {err}"));
+                        KeyResponse::Nothing
+                    },
+                }
+            },
+        }
     }
 
     fn render_main(&mut self) {
@@ -281,8 +356,7 @@ impl<'a> TuiSession<'a> {
                 KeyResponse::Nothing
             }
             (TuiState::Main, KeyCode::Char('R'), _) => {
-                self.auto_sample = !self.auto_sample;
-                KeyResponse::Nothing
+                self.perform_action(tx_port, &TuiAction::SetAutoRearm(!self.auto_reset))
             }
             (TuiState::Main, KeyCode::Char(' '), _) => {
                 self.triggered = match perform_register_operation(
@@ -377,25 +451,8 @@ impl<'a> TuiSession<'a> {
                         KeyResponse::Nothing
                     }
                     PromptReason::ChangeTrigger => match prompt.input.parse() {
-                        Ok(n) if n > self.config.buffer_size as u32 => {
-                            self.log
-                                .push("Invalid input; must be specified range".to_string());
-                            KeyResponse::Nothing
-                        }
                         Ok(n) => {
-                            let (msg, response) = match perform_register_operation(
-                                tx_port,
-                                self.config,
-                                &IlaRegisters::TriggerPoint(n),
-                            ) {
-                                Ok(_) => (
-                                    String::from("Trigger point change made"),
-                                    KeyResponse::AppliedChanges,
-                                ),
-                                Err(err) => (format!("Error: {err}"), KeyResponse::Nothing),
-                            };
-                            self.log.push(msg);
-                            response
+                            self.perform_action(tx_port, &TuiAction::SetTriggerPoint(n))
                         }
                         Err(_) => {
                             self.log.push(
@@ -426,6 +483,10 @@ impl<'a> TuiSession<'a> {
     /// Handles everything from rendering to the input of the TUI interface
     pub fn main_loop<T: Read + Write>(&mut self, mut tx_port: T) {
         self.render();
+        let actions = std::mem::take(&mut self.actions);
+        for action in &actions {
+            self.perform_action(&mut tx_port, action);
+        }
 
         let mut last_should_sample = false;
         loop {

--- a/ila/src/Clash/Ila/Configurator.hs
+++ b/ila/src/Clash/Ila/Configurator.hs
@@ -78,7 +78,7 @@ simplePredicate :: forall dom a.
 simplePredicate f = pure f
 
 -- | Same as `Predicate dom a` but with a string to display in the CLI
-type NamedPredicate dom a = (Predicate dom a, String)
+type NamedPredicate dom a = (Predicate dom a, String, String)
 
 {- | Default ILA predicate for checking equality
 It applies the mask over the incoming sample and `==` it with the compare value
@@ -119,11 +119,11 @@ ilaPredicateFalse = simplePredicate ilaPredicateFalse'
 -- | Predefined list of three ILA predicates. The operators it covers are: `==`, `>`, `<`
 ilaDefaultPredicates :: forall dom a. (BitPack a) => Vec 5 (NamedPredicate dom a)
 ilaDefaultPredicates =
-  ( (ilaPredicateEq, "Equals")
-      :> (ilaPredicateGt, "Greater than")
-      :> (ilaPredicateLt, "Less than")
-      :> (ilaPredicateTrue, "Always true")
-      :> (ilaPredicateFalse, "Always false")
+  ( (ilaPredicateEq, "Equals", "eq")
+      :> (ilaPredicateGt, "Greater than", "gt")
+      :> (ilaPredicateLt, "Less than", "lt")
+      :> (ilaPredicateTrue, "Always true", "true")
+      :> (ilaPredicateFalse, "Always false", "false")
       :> Nil
   )
 
@@ -213,10 +213,10 @@ instance
       , triggerPoint = triggerPoint
       , hash = ilaHash
       , tracing = tracing
-      , predicates = fst <$> predicates
+      , predicates = (\(p, _, _) -> p) <$> predicates
       }
    where
-    ilaHash = writeSignalInfo toplevel bufferDepth (fromGenSignal <$> signalInfos) (snd <$> predicates)
+    ilaHash = writeSignalInfo toplevel bufferDepth (fromGenSignal <$> signalInfos) ((\(_, n, _) -> n) <$> predicates) ((\(_, _, id) -> id) <$> predicates)
 
 {- | General case
 For every pair of new set of `(Signal dom a, "name")`, bundle the signal and collect the name
@@ -283,9 +283,10 @@ writeSignalInfo ::
   -- | A `Vec` of signal widths and their label
   Vec n (Int, String) ->
   Vec m String ->
+  Vec m String ->
   -- | The hash of the JSON
   BitVector 32
-writeSignalInfo !_toplevel !_bufSize !_sigInfo !_triggerNames = 0
+writeSignalInfo !_toplevel !_bufSize !_sigInfo !_triggerNames !_triggerIds = 0
 {-# OPAQUE writeSignalInfo #-}
 {-# ANN writeSignalInfo hasBlackBox #-}
 {-# ANN
@@ -313,7 +314,7 @@ signalInfoBBF :: (HasCallStack) => BlackBoxFunction
 signalInfoBBF _ _ args _ = view tcCache >>= go
  where
   go tcm
-    | [toplevel, _, sigInfo, triggerNames] <- lefts args
+    | [toplevel, _, sigInfo, triggerNames, triggerIds] <- lefts args
     , [ (coreView tcm -> LitTy (NumTy n))
         , (coreView tcm -> LitTy (NumTy m))
         , (coreView tcm -> LitTy (NumTy s))
@@ -328,6 +329,7 @@ signalInfoBBF _ _ args _ = view tcCache >>= go
             (SNat @s)
             (getSigInfo sigInfo)
             (coerceTermToType triggerNames)
+            (coerceTermToType triggerIds)
     | otherwise =
         errorX
           "AST does not match expected, expected AST in the form of String -> SNat -> Vec n (Int, String)"
@@ -360,8 +362,9 @@ signalInfoBBF _ _ args _ = view tcCache >>= go
     SNat s ->
     Vec n (Int, String) ->
     Vec m (String) ->
+    Vec m (String) ->
     GenIla
-  getGenIla toplevel bufSize sigInfo triggerNames =
+  getGenIla toplevel bufSize sigInfo triggerNames triggerIds =
     GenIla
       { toplevel = coerceTermToType toplevel
       , bufferSize = snatToNum bufSize
@@ -375,6 +378,7 @@ signalInfoBBF _ _ args _ = view tcCache >>= go
       , -- The reverse is needed as the polyvariadic function builds up the vector in reverse order
         signals = P.reverse $ toList $ toGenSignal <$> sigInfo
       , triggerNames = toList triggerNames
+      , triggerIds = toList triggerIds
       }
 
   -- \| Meta information about the blackbox
@@ -459,5 +463,6 @@ data GenIla = GenIla
   , hash :: Word32
   , signals :: [GenSignal]
   , triggerNames :: [String]
+  , triggerIds :: [String]
   }
   deriving (Generic, Show, ToJSON, Eq, Hashable)


### PR DESCRIPTION
# Lua Scripting for Clash-ILA

> [!NOTE]  
> This PR is prototype and is not intended to be merged in the near future (or ever).
> The code itself is a very rough scetch that was written some weeks ago. It is not inteded to be reviewed.

One feature I would've liked for the ILA is being able to configure presets for the core. Initially I've thought about handling this on the CLI side and looked at different file formats for achieving this.

As the CLI is written in Rust, TOML seemed like a good tool for this; however, I've quickly ran into the limitations of static configuration formats. Because these generally do not allow for expressions, it's difficult to write configurations that are independent of the test setup, e.g., having a trigger point that is always halfway though the buffer, regardless of the buffer's size.

I ended up looking at Lua as it's well known for being embeddable, and I was already familiar with it. Upon starting the TUI, the CLI looks for a `.ila.lua` file in its process's working directory. If this file exist, the contents of it gets interpreted as Lua by the CLI.

## The API by Example

I've come up with an API of which an example usage is shown below:

```lua
print("Hello from the Clash-ILA!")

ila.config({
  trigger_point = ila.buffer_size // 2,
  auto_rearm = true,
})
```

A `print` function is exposed that appends a message to the log section of the main screen. This function can, for example, be used for printing information about the test setup:

```lua
print(("Observing '%s' (%x)."):format(ila.toplevel, ila.hash))
-- Could log: Observing 'Simple_Demo' (42c9cd00).
```

`ila` is a table (i.e., key-value pairs) providing context about the ILA. In one of the previous code snippets, it allowed for setting the trigger point to halfway though the buffer.

`ila.config` is a function that takes a table and, for each key in the provided table, updates the corresponding aspect of the ILA. If the same key appears in multiple calls, the value from the most recent call takes precedence. The following:

```lua
ila.config({
  trigger_point = ila.buffer_size - 1,
  auto_rearm = true,
})

ila.config({
  auto_rearm = false,
})
```

Should be semantically the same as:

```lua
ila.config({
  trigger_point = ila.buffer_size - 1,
  auto_rearm = false,
})
```

(This is not completely the case yet in the prototype. There it would first enable auto-rearming and then disable it.)

Lua only supports double-precision floats and 64-bit integers, which makes it tricky to numerically represent mask and compare values for predicates, as these are as wide as the signals they are associated with. I ended up representing these values as strings, using the same format as the input fields in the CLI.

To configure the capture predicates:

```lua
local masks = {}
for i, signal in ipairs(ila.inputs) do
  masks[i] = "0b" .. string.rep("1", signal.width)
end

local compares = {}
for i, signal in ipairs(ila.inputs) do
  compares[i] = "0"
end

ila.config({
  capture = {
    predicates = { "gt", "eq" },
    combine = "or",
    masks = masks,
    compares = compares,
  },
})
```

## The Overhead of Embedding Lua

In the prototype, the complete Lua virtual machine is bundled with the CLI. The release build of the inital CLI takes up about 2.3 MB, while the version including Lua is about 2.8 MB. This does not include the additional code required to integrate Lua with the CLI.

## Potential Future Work

If the goal is to just configure presets for the ILA-core, I believe doing so in Clash would be the better solution. If the goal is to also control the ILA-CLI, I think embedding Lua, or any other suitable programming language, would be a cool way of achieving this. Potential additions to this prototype are:

- Besides `print`, provide more utilities for providing feedback to the user.
- Callbacks for events such as when the ILA-core is triggered or when samples are received.
- Controlling the output signals.
- Exporting samples.
